### PR TITLE
Explicitly make DAG.Streams a monoid

### DIFF
--- a/src/Arduino/Internal/DAG.hs
+++ b/src/Arduino/Internal/DAG.hs
@@ -18,6 +18,7 @@
 module Arduino.Internal.DAG where
 
 import Control.Monad.State
+import Data.Monoid
 import Data.Maybe (fromJust)
 import qualified Data.Map as M
 
@@ -73,6 +74,9 @@ type Identifier = String
 
 emptyStreams :: Streams
 emptyStreams = M.empty
+
+liftStream :: Stream -> Streams
+liftStream = addStream emptyStreams
 
 addStream :: Streams -> Stream -> Streams
 addStream streams stream = M.insert (name stream) stream streams

--- a/src/Arduino/Internal/DAG.hs
+++ b/src/Arduino/Internal/DAG.hs
@@ -78,6 +78,9 @@ emptyStreams = M.empty
 liftStream :: Stream -> Streams
 liftStream = addStream emptyStreams
 
+liftStreams :: [Stream] -> Streams
+liftStreams = mconcat . map liftStream
+
 addStream :: Streams -> Stream -> Streams
 addStream streams stream = M.insert (name stream) stream streams
 


### PR DESCRIPTION
Because `Streams = M.Map Identifier Stream` and `M.Map` is a `Monoid`, `Streams` is also a `Monoid`.

Thus the following is now possible

``` haskell
Streams3 = Streams1 <> Streams2
```

which merges 2 Streams.
