### PR TITLE
Problem: C code might take adress of literal expression.

### DIFF
--- a/examples/Blink.c
+++ b/examples/Blink.c
@@ -29,73 +29,61 @@ static void input_timer() {
 
 static void stream_1(uint8_t arg, void* value) {
   static uint16_t input_1 = 0;
-  bool temp1;
-  uint16_t temp2;
-  uint16_t temp3;
-  uint16_t temp4;
-  uint16_t temp5;
+  uint16_t temp1;
   static uint16_t input_0;
   switch (arg) {
     case 0:
       input_0 = *((uint16_t*)value);
       break;
   }
-  temp1 = input_1 > 10000;
-  temp2 = input_1 - 10000;
-  temp3 = temp2 + input_0;
-  temp4 = input_1 + input_0;
-  if (temp1) {
-    temp5 = temp3;
+  if (input_1 > 10000) {
+    temp1 = input_1 - 10000 + input_0;
   } else {
-    temp5 = temp4;
+    temp1 = input_1 + input_0;
   }
-  input_1 = temp5;
+  input_1 = temp1;
   stream_2(0, (void*)(&input_1));
 }
 
 static void stream_2(uint8_t arg, void* value) {
-  bool temp6;
-  bool temp7;
+  bool temp2;
   static uint16_t input_0;
   switch (arg) {
     case 0:
       input_0 = *((uint16_t*)value);
       break;
   }
-  temp6 = input_0 > 10000;
-  temp7 = false;
-  if (temp6) {
-    temp7 = true;
+  temp2 = false;
+  if (input_0 > 10000) {
+    temp2 = true;
   }
-  if (temp7) {
+  if (temp2) {
     stream_3(0, (void*)(&input_0));
   }
 }
 
 static void stream_3(uint8_t arg, void* value) {
   static uint16_t input_1 = 0;
-  uint16_t temp8;
   static uint16_t input_0;
   switch (arg) {
     case 0:
       input_0 = *((uint16_t*)value);
       break;
   }
-  temp8 = input_1 + 1;
-  input_1 = temp8;
+  input_1 = input_1 + 1;
   stream_4(0, (void*)(&input_1));
 }
 
 static void stream_4(uint8_t arg, void* value) {
-  bool temp9;
+  bool temp3;
   static uint16_t input_0;
   switch (arg) {
     case 0:
       input_0 = *((uint16_t*)value);
       break;
   }
-  temp9 = (input_0) % 2 == 0;
-  stream_5(0, (void*)(&temp9));
+  temp3 = (input_0) % 2 == 0;
+  stream_5(0, (void*)(&temp3));
 }
 
 static void stream_5(uint8_t arg, void* value) {

--- a/examples/Combine.c
+++ b/examples/Combine.c
@@ -49,27 +49,19 @@ static void input_timer() {
 
 static void stream_1(uint8_t arg, void* value) {
   static uint16_t input_1 = 0;
-  bool temp2;
-  uint16_t temp3;
-  uint16_t temp4;
-  uint16_t temp5;
-  uint16_t temp6;
+  uint16_t temp2;
   static uint16_t input_0;
   switch (arg) {
     case 0:
       input_0 = *((uint16_t*)value);
       break;
   }
-  temp2 = input_1 > 10000;
-  temp3 = input_1 - 10000;
-  temp4 = temp3 + input_0;
-  temp5 = input_1 + input_0;
-  if (temp2) {
-    temp6 = temp4;
+  if (input_1 > 10000) {
+    temp2 = input_1 - 10000 + input_0;
   } else {
-    temp6 = temp5;
+    temp2 = input_1 + input_0;
   }
-  input_1 = temp6;
+  input_1 = temp2;
   stream_2(0, (void*)(&input_1));
 }
 
@@ -88,53 +80,49 @@ static void stream_5(uint8_t arg, void* value) {
 }
 
 static void stream_2(uint8_t arg, void* value) {
-  bool temp7;
-  bool temp8;
+  bool temp3;
   static uint16_t input_0;
   switch (arg) {
     case 0:
       input_0 = *((uint16_t*)value);
       break;
   }
-  temp7 = input_0 > 10000;
-  temp8 = false;
-  if (temp7) {
-    temp8 = true;
+  temp3 = false;
+  if (input_0 > 10000) {
+    temp3 = true;
   }
-  if (temp8) {
+  if (temp3) {
     stream_3(0, (void*)(&input_0));
   }
 }
 
 static void stream_3(uint8_t arg, void* value) {
   static uint16_t input_1 = 0;
-  uint16_t temp9;
   static uint16_t input_0;
   switch (arg) {
     case 0:
       input_0 = *((uint16_t*)value);
       break;
   }
-  temp9 = input_1 + 1;
-  input_1 = temp9;
+  input_1 = input_1 + 1;
   stream_4(0, (void*)(&input_1));
 }
 
 static void stream_4(uint8_t arg, void* value) {
-  bool temp10;
+  bool temp4;
   static uint16_t input_0;
   switch (arg) {
     case 0:
       input_0 = *((uint16_t*)value);
       break;
   }
-  temp10 = (input_0) % 2 == 0;
-  stream_6(1, (void*)(&temp10));
-  stream_8(0, (void*)(&temp10));
+  temp4 = (input_0) % 2 == 0;
+  stream_6(1, (void*)(&temp4));
+  stream_8(0, (void*)(&temp4));
 }
 
 static void stream_6(uint8_t arg, void* value) {
-  bool temp11;
+  bool temp5;
   static bool input_0;
   static bool input_1;
   switch (arg) {
@@ -146,23 +134,23 @@ static void stream_6(uint8_t arg, void* value) {
       break;
   }
   if (input_0) {
-    temp11 = input_1;
+    temp5 = input_1;
   } else {
-    temp11 = false;
+    temp5 = false;
   }
-  stream_7(0, (void*)(&temp11));
+  stream_7(0, (void*)(&temp5));
 }
 
 static void stream_8(uint8_t arg, void* value) {
-  bool temp12;
+  bool temp6;
   static bool input_0;
   switch (arg) {
     case 0:
       input_0 = *((bool*)value);
       break;
   }
-  temp12 = !(input_0);
-  stream_9(1, (void*)(&temp12));
+  temp6 = !(input_0);
+  stream_9(1, (void*)(&temp6));
 }
 
 static void stream_7(uint8_t arg, void* value) {
@@ -180,7 +168,7 @@ static void stream_7(uint8_t arg, void* value) {
 }
 
 static void stream_9(uint8_t arg, void* value) {
-  bool temp13;
+  bool temp7;
   static bool input_0;
   static bool input_1;
   switch (arg) {
@@ -192,11 +180,11 @@ static void stream_9(uint8_t arg, void* value) {
       break;
   }
   if (input_0) {
-    temp13 = input_1;
+    temp7 = input_1;
   } else {
-    temp13 = false;
+    temp7 = false;
   }
-  stream_10(0, (void*)(&temp13));
+  stream_10(0, (void*)(&temp7));
 }
 
 static void stream_10(uint8_t arg, void* value) {

--- a/examples/DoubleBlink.c
+++ b/examples/DoubleBlink.c
@@ -33,74 +33,62 @@ static void input_timer() {
 
 static void stream_1(uint8_t arg, void* value) {
   static uint16_t input_1 = 0;
-  bool temp1;
-  uint16_t temp2;
-  uint16_t temp3;
-  uint16_t temp4;
-  uint16_t temp5;
+  uint16_t temp1;
   static uint16_t input_0;
   switch (arg) {
     case 0:
       input_0 = *((uint16_t*)value);
       break;
   }
-  temp1 = input_1 > 10000;
-  temp2 = input_1 - 10000;
-  temp3 = temp2 + input_0;
-  temp4 = input_1 + input_0;
-  if (temp1) {
-    temp5 = temp3;
+  if (input_1 > 10000) {
+    temp1 = input_1 - 10000 + input_0;
   } else {
-    temp5 = temp4;
+    temp1 = input_1 + input_0;
   }
-  input_1 = temp5;
+  input_1 = temp1;
   stream_2(0, (void*)(&input_1));
 }
 
 static void stream_2(uint8_t arg, void* value) {
-  bool temp6;
-  bool temp7;
+  bool temp2;
   static uint16_t input_0;
   switch (arg) {
     case 0:
       input_0 = *((uint16_t*)value);
       break;
   }
-  temp6 = input_0 > 10000;
-  temp7 = false;
-  if (temp6) {
-    temp7 = true;
+  temp2 = false;
+  if (input_0 > 10000) {
+    temp2 = true;
   }
-  if (temp7) {
+  if (temp2) {
     stream_3(0, (void*)(&input_0));
   }
 }
 
 static void stream_3(uint8_t arg, void* value) {
   static uint16_t input_1 = 0;
-  uint16_t temp8;
   static uint16_t input_0;
   switch (arg) {
     case 0:
       input_0 = *((uint16_t*)value);
       break;
   }
-  temp8 = input_1 + 1;
-  input_1 = temp8;
+  input_1 = input_1 + 1;
   stream_4(0, (void*)(&input_1));
 }
 
 static void stream_4(uint8_t arg, void* value) {
-  bool temp9;
+  bool temp3;
   static uint16_t input_0;
   switch (arg) {
     case 0:
       input_0 = *((uint16_t*)value);
       break;
   }
-  temp9 = (input_0) % 2 == 0;
-  stream_5(0, (void*)(&temp9));
-  stream_6(0, (void*)(&temp9));
+  temp3 = (input_0) % 2 == 0;
+  stream_5(0, (void*)(&temp3));
+  stream_6(0, (void*)(&temp3));
 }
 
 static void stream_5(uint8_t arg, void* value) {
@@ -118,15 +106,15 @@ static void stream_5(uint8_t arg, void* value) {
 }
 
 static void stream_6(uint8_t arg, void* value) {
-  bool temp10;
+  bool temp4;
   static bool input_0;
   switch (arg) {
     case 0:
       input_0 = *((bool*)value);
       break;
   }
-  temp10 = !(input_0);
-  stream_7(0, (void*)(&temp10));
+  temp4 = !(input_0);
+  stream_7(0, (void*)(&temp4));
 }
 
 static void stream_7(uint8_t arg, void* value) {

--- a/examples/Input.c
+++ b/examples/Input.c
@@ -53,73 +53,61 @@ static void stream_1(uint8_t arg, void* value) {
 
 static void stream_2(uint8_t arg, void* value) {
   static uint16_t input_1 = 0;
-  bool temp2;
-  uint16_t temp3;
-  uint16_t temp4;
-  uint16_t temp5;
-  uint16_t temp6;
+  uint16_t temp2;
   static uint16_t input_0;
   switch (arg) {
     case 0:
       input_0 = *((uint16_t*)value);
       break;
   }
-  temp2 = input_1 > 10000;
-  temp3 = input_1 - 10000;
-  temp4 = temp3 + input_0;
-  temp5 = input_1 + input_0;
-  if (temp2) {
-    temp6 = temp4;
+  if (input_1 > 10000) {
+    temp2 = input_1 - 10000 + input_0;
   } else {
-    temp6 = temp5;
+    temp2 = input_1 + input_0;
   }
-  input_1 = temp6;
+  input_1 = temp2;
   stream_3(0, (void*)(&input_1));
 }
 
 static void stream_3(uint8_t arg, void* value) {
-  bool temp7;
-  bool temp8;
+  bool temp3;
   static uint16_t input_0;
   switch (arg) {
     case 0:
       input_0 = *((uint16_t*)value);
       break;
   }
-  temp7 = input_0 > 10000;
-  temp8 = false;
-  if (temp7) {
-    temp8 = true;
+  temp3 = false;
+  if (input_0 > 10000) {
+    temp3 = true;
   }
-  if (temp8) {
+  if (temp3) {
     stream_4(0, (void*)(&input_0));
   }
 }
 
 static void stream_4(uint8_t arg, void* value) {
   static uint16_t input_1 = 0;
-  uint16_t temp9;
   static uint16_t input_0;
   switch (arg) {
     case 0:
       input_0 = *((uint16_t*)value);
       break;
   }
-  temp9 = input_1 + 1;
-  input_1 = temp9;
+  input_1 = input_1 + 1;
   stream_5(0, (void*)(&input_1));
 }
 
 static void stream_5(uint8_t arg, void* value) {
-  bool temp10;
+  bool temp4;
   static uint16_t input_0;
   switch (arg) {
     case 0:
       input_0 = *((uint16_t*)value);
       break;
   }
-  temp10 = (input_0) % 2 == 0;
-  stream_6(0, (void*)(&temp10));
+  temp4 = (input_0) % 2 == 0;
+  stream_6(0, (void*)(&temp4));
 }
 
 static void stream_6(uint8_t arg, void* value) {

--- a/examples/UART.c
+++ b/examples/UART.c
@@ -36,125 +36,95 @@ static void input_timer() {
 
 static void stream_1(uint8_t arg, void* value) {
   static uint16_t input_1 = 0;
-  bool temp1;
-  uint16_t temp2;
-  uint16_t temp3;
-  uint16_t temp4;
-  uint16_t temp5;
+  uint16_t temp1;
   static uint16_t input_0;
   switch (arg) {
     case 0:
       input_0 = *((uint16_t*)value);
       break;
   }
-  temp1 = input_1 > 10000;
-  temp2 = input_1 - 10000;
-  temp3 = temp2 + input_0;
-  temp4 = input_1 + input_0;
-  if (temp1) {
-    temp5 = temp3;
+  if (input_1 > 10000) {
+    temp1 = input_1 - 10000 + input_0;
   } else {
-    temp5 = temp4;
+    temp1 = input_1 + input_0;
   }
-  input_1 = temp5;
+  input_1 = temp1;
   stream_2(0, (void*)(&input_1));
 }
 
 static void stream_6(uint8_t arg, void* value) {
-  uint8_t temp6;
-  uint8_t temp7;
-  uint8_t temp8;
-  uint8_t temp9;
-  uint8_t temp10;
-  uint8_t temp11;
-  uint8_t temp12;
-  struct list temp13;
-  uint8_t temp14[7];
-  uint8_t temp15[20];
-  struct list temp16;
-  uint8_t temp17;
-  uint8_t temp18;
-  struct list temp19;
-  uint8_t temp20[2];
+  struct list temp2;
+  uint8_t temp3[7];
+  uint8_t temp4[20];
+  struct list temp5;
+  struct list temp6;
+  uint8_t temp7[2];
   static uint16_t input_0;
   switch (arg) {
     case 0:
       input_0 = *((uint16_t*)value);
       break;
   }
-  temp6 = 100;
-  temp7 = 101;
-  temp8 = 108;
-  temp9 = 116;
-  temp10 = 97;
-  temp11 = 58;
-  temp12 = 32;
-  temp14[0] = temp6;
-  temp14[1] = temp7;
-  temp14[2] = temp8;
-  temp14[3] = temp9;
-  temp14[4] = temp10;
-  temp14[5] = temp11;
-  temp14[6] = temp12;
-  temp13.size = 7;
-  temp13.values = (void*)temp14;
-  snprintf(temp15, 20, "%d", input_0);
-  temp16.size = strlen(temp15);
-  temp16.values = temp15;
-  temp17 = 13;
-  temp18 = 10;
-  temp20[0] = temp17;
-  temp20[1] = temp18;
-  temp19.size = 2;
-  temp19.values = (void*)temp20;
-  stream_7(0, (void*)(&temp13));
-  stream_7(0, (void*)(&temp16));
-  stream_7(0, (void*)(&temp19));
+  temp3[0] = 100;
+  temp3[1] = 101;
+  temp3[2] = 108;
+  temp3[3] = 116;
+  temp3[4] = 97;
+  temp3[5] = 58;
+  temp3[6] = 32;
+  temp2.size = 7;
+  temp2.values = (void*)temp3;
+  snprintf(temp4, 20, "%d", input_0);
+  temp5.size = strlen(temp4);
+  temp5.values = temp4;
+  temp7[0] = 13;
+  temp7[1] = 10;
+  temp6.size = 2;
+  temp6.values = (void*)temp7;
+  stream_7(0, (void*)(&temp2));
+  stream_7(0, (void*)(&temp5));
+  stream_7(0, (void*)(&temp6));
 }
 
 static void stream_2(uint8_t arg, void* value) {
-  bool temp21;
-  bool temp22;
+  bool temp8;
   static uint16_t input_0;
   switch (arg) {
     case 0:
       input_0 = *((uint16_t*)value);
       break;
   }
-  temp21 = input_0 > 10000;
-  temp22 = false;
-  if (temp21) {
-    temp22 = true;
+  temp8 = false;
+  if (input_0 > 10000) {
+    temp8 = true;
   }
-  if (temp22) {
+  if (temp8) {
     stream_3(0, (void*)(&input_0));
   }
 }
 
 static void stream_7(uint8_t arg, void* value) {
-  uint8_t temp23;
+  uint8_t temp9;
   static struct list input_0;
   switch (arg) {
     case 0:
       input_0 = *((struct list*)value);
       break;
   }
-  for (temp23 = 0; temp23 < input_0.size; temp23++) {
-    stream_8(0, (void*)(&((uint8_t*)input_0.values)[temp23]));
+  for (temp9 = 0; temp9 < input_0.size; temp9++) {
+    stream_8(0, (void*)(&((uint8_t*)input_0.values)[temp9]));
   }
 }
 
 static void stream_3(uint8_t arg, void* value) {
   static uint16_t input_1 = 0;
-  uint16_t temp24;
   static uint16_t input_0;
   switch (arg) {
     case 0:
       input_0 = *((uint16_t*)value);
       break;
   }
-  temp24 = input_1 + 1;
-  input_1 = temp24;
+  input_1 = input_1 + 1;
   stream_4(0, (void*)(&input_1));
 }
 
@@ -171,15 +141,15 @@ static void stream_8(uint8_t arg, void* value) {
 }
 
 static void stream_4(uint8_t arg, void* value) {
-  bool temp25;
+  bool temp10;
   static uint16_t input_0;
   switch (arg) {
     case 0:
       input_0 = *((uint16_t*)value);
       break;
   }
-  temp25 = (input_0) % 2 == 0;
-  stream_5(0, (void*)(&temp25));
+  temp10 = (input_0) % 2 == 0;
+  stream_5(0, (void*)(&temp10));
 }
 
 static void stream_5(uint8_t arg, void* value) {


### PR DESCRIPTION
Example:

```
stream_5(0, &54);
```

Where 54 is the result of a stream calculation.

Solution: Always wrap result in a variable:

```
uint8_t temp = 54;
stream_5(0, &temp);
```

While the result is calculated, literal expressions may be used.
