### PR TITLE
fix frp-arduino for ghc 7.10.1

### DIFF
--- a/src/Arduino/Internal/DAG.hs
+++ b/src/Arduino/Internal/DAG.hs
@@ -23,6 +23,7 @@ import Data.Monoid
 import qualified Data.Map as M
 import qualified Data.Set as S
 import qualified Data.Word as W
+import Prelude hiding (Word)
 
 type Streams = M.Map Identifier Stream
 

--- a/src/Arduino/Library.hs
+++ b/src/Arduino/Library.hs
@@ -26,6 +26,7 @@ module Arduino.Library
 import Arduino.DSL
 import Arduino.Library.Time
 import Arduino.Library.Tuples
+import Prelude hiding (Word)
 
 toggle :: Stream Word -> Stream Bit
 toggle = mapS (boolToBit . isEven)

--- a/src/Arduino/Library/LCD.hs
+++ b/src/Arduino/Library/LCD.hs
@@ -25,7 +25,7 @@ module Arduino.Library.LCD
 import Arduino.DSL
 import Data.Bits
 import Data.Char (ord)
-import Prelude hiding (init)
+import Prelude hiding (init, Word)
 
 type Command = (Bit, Bit, Bit, Bit, Bit, Word)
 

--- a/src/Arduino/Library/Time.hs
+++ b/src/Arduino/Library/Time.hs
@@ -22,6 +22,7 @@ module Arduino.Library.Time
 
 import Arduino.DSL
 import Arduino.Library.Tuples
+import Prelude hiding (Word)
 
 -- | The snippet
 --

--- a/src/Arduino/Uno.hs
+++ b/src/Arduino/Uno.hs
@@ -49,6 +49,7 @@ module Arduino.Uno
 import Arduino.DSL
 import Arduino.Library
 import Data.Bits (shiftR, (.&.), testBit)
+import Prelude hiding (Word)
 
 data GPIO = GPIO
     { name              :: String


### PR DESCRIPTION
the library didn't build for me on ghc 7.10.1 because the prelude now includes Data.Word.
https://ghc.haskell.org/trac/ghc/wiki/Migration/7.10#GHCsaysTheimportof...isredundant

this commit fixed it for me
