### PR TITLE
Added Pin 9 For Arduino Uno and Fixed Tests

### DIFF
--- a/.frp.en.pws
+++ b/.frp.en.pws
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 27 
+personal_ws-1.1 en 27
 AnalogInput
 analogRead
 analogToLimit
@@ -40,6 +40,8 @@ Hackage
 haskell
 Haskell's
 href
+hspec
+Hspec
 img
 incrementing
 init

--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ commands:
     yum install arduino-core
     git clone https://github.com/sudar/Arduino-Makefile.git
 
+Hspec is required for tests to pass:
+
+    cabal update && cabal install hspec
+
 The arduino-core package depends on the following packages:
 
 * avr-gcc

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ commands:
     yum install arduino-core
     git clone https://github.com/sudar/Arduino-Makefile.git
 
-hspec is required for tests to pass:
+Hspec is required for tests to pass:
 
     cabal update && cabal install hspec
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ commands:
     yum install arduino-core
     git clone https://github.com/sudar/Arduino-Makefile.git
 
-Hspec is required for tests to pass:
+hspec is required for tests to pass:
 
     cabal update && cabal install hspec
 

--- a/examples/FrequencyBlink.hs
+++ b/examples/FrequencyBlink.hs
@@ -30,7 +30,7 @@ setupAlternateBlink pin1 pin2 triggerStream = do
 createVariableTick :: AnalogInput -> Stream ()
 createVariableTick limitInput = accumulator limitStream timerDelta
     where
-        limitStream :: Stream Word
+        limitStream :: Stream Arduino.Uno.Word
         limitStream = analogRead limitInput ~> mapS analogToLimit
-        analogToLimit :: Expression Word -> Expression Word
+        analogToLimit :: Expression Arduino.Uno.Word -> Expression Arduino.Uno.Word
         analogToLimit analog = 1000 + analog * 20

--- a/examples/LCD.hs
+++ b/examples/LCD.hs
@@ -32,7 +32,7 @@ introText = concat
     , LCD.text "FRP Arduino"
     ]
 
-statusText :: Expression Word -> [Expression LCD.Command]
+statusText :: Expression Arduino.Uno.Word -> [Expression LCD.Command]
 statusText delta = concat
     [ LCD.position 1 0
     , LCD.text ":-)"

--- a/examples/UART.hs
+++ b/examples/UART.hs
@@ -21,7 +21,7 @@ main = compileProgram $ do
 
     uart =: timerDelta ~> mapSMany formatDelta ~> flattenS
 
-formatDelta :: Expression Word -> [Expression [Byte]]
+formatDelta :: Expression Arduino.Uno.Word -> [Expression [Byte]]
 formatDelta delta = [ formatString "delta: "
                     , formatNumber delta
                     , formatString "\r\n"

--- a/src/Arduino/Uno.hs
+++ b/src/Arduino/Uno.hs
@@ -28,6 +28,7 @@ module Arduino.Uno
     , pin6
     , pin7
     , pin8
+    , pin9
     , pin10
     , pin11
     , pin12
@@ -83,6 +84,9 @@ pin7 = GPIO "pin7" "DDRD" "PORTD" "PIND" "PD7"
 
 pin8 :: GPIO
 pin8 = GPIO "pin8" "DDRB" "PORTB" "PINB" "PB0"
+
+pin9 :: GPIO
+pin9 = GPIO "pin9" "DDRB" "PORTB" "PINB" "PB1"
 
 pin10 :: GPIO
 pin10 = GPIO "pin10" "DDRB" "PORTB" "PINB" "PB2"


### PR DESCRIPTION
This should address issue #41 

This has been tested on an Uno running the Blink example with an LED connected to pin 9. The LED blinks as expected. The Word type ambiguity fix (ghc 8.0.2) was tested by running the FrequencyBlink example. The LEDs also blink as expected there.

I also updated the readme to let people newer to Haskell (like me) know that they need to install Hspec to get the tests to run.

My setup: ghc 8.0.2 on Ubuntu 17.10 64-bit.