### PR TITLE
Fix build failure with ghc v8.6

### DIFF
--- a/src/Arduino/Internal/CodeGen/C.hs
+++ b/src/Arduino/Internal/CodeGen/C.hs
@@ -22,8 +22,10 @@ module Arduino.Internal.CodeGen.C
 import Arduino.Internal.CodeGen.BlockDoc
 import Arduino.Internal.DAG
 import Control.Monad
+import qualified Control.Monad.Fail as Fail
 import Data.List (intersperse)
 import qualified Data.Map as M
+import Data.Functor.Identity as Identity
 
 data ResultValue = Value String CType Storage (Maybe String)
                  | FilterVariable String CType String
@@ -40,6 +42,9 @@ data CType = CBit
            | CList CType
            | CTuple [CType]
            deriving (Eq, Show)
+
+instance Fail.MonadFail Identity.Identity where
+    fail = error "assumption failed in pattern matching"
 
 listSizeCType :: CType
 listSizeCType = CByte


### PR DESCRIPTION
Semi-authoritative tone in the commit message notwithstanding, please don't assume that I have any idea what I am doing ☺ I have like 20 hours of Haskell under my belt, and I only have the most ELI5-ish general understanding of what a monad is — Mostly I took hints from [here](https://github.com/quchen/articles/blob/master/monad_fail.md), [there](http://hackage.haskell.org/package/base-4.12.0.0/docs/src/Control.Monad.Fail.html#fail) and the compiler error messages (the latter get credit for the idea of applying the `MonadFail`  onto, of all things, the `Identity.Identity` function or functor something something)

Also, it appears that one could get away with [a bunch of tildes](https://github.com/domq/frp-arduino/commit/fix-build-with-tildes) instead but where is the fun in that, right?