### PR TITLE
Mac OS X-specific improvements to `make`

### DIFF
--- a/make
+++ b/make
@@ -47,7 +47,14 @@ else
     ./$BASENAME
 
     if ! [ -n "$ARDUINO_MAKEFILE_PATH" ]; then
-        ARDUINO_MAKEFILE_PATH="../../Arduino-Makefile/Arduino.mk"
+        case "$(uname -s)" in
+            Darwin)
+                # Assume Arduino-Makefile was installed with `brew install arduino-mk`
+                ARDUINO_MAKEFILE_PATH="/usr/local/opt/arduino-mk/Arduino.mk" ;;
+            *)
+                # Assume both projects are checked out from source side by side
+                ARDUINO_MAKEFILE_PATH="../../Arduino-Makefile/Arduino.mk" ;;
+        esac
     fi
 
 		# Add new boards as an elif statement here after creating a matching

--- a/make
+++ b/make
@@ -74,7 +74,10 @@ else
     if [ "$TARGET" == "dot" ];
     then
         dot -Tpng -odag.png dag.dot
-        xdg-open dag.png
+        case "$(uname -s)" in
+            Darwin) open dag.png ;;
+            *) xdg-open dag.png ;;
+        esac
     else
         make $TARGET
     fi


### PR DESCRIPTION
- On Mac OS X, default to using `Arduino.mk` out of where Homebrew puts it
- Likewise, use `open` instead of `xdg-open` on Darwin
